### PR TITLE
Restrict pytorch version for cuda compatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Then follow the instructions at https://docs.anaconda.com/anaconda/install/linux
 
 `conda install pytorch torchvision cudatoolkit=9.2 -c pytorch`
 
-For the new server this should be:
+For uhlergroup2.mit.edu this should be:
 
-`conda install pytorch torchvision cudatoolkit=10.1 -c pytorch`
+`conda install pytorch=1.8.1 torchvision=0.9.1 cudatoolkit=10.1 -c pytorch -c nvidia`
 
 5. To test the installation, just run: `python` followed by `import torch`
 


### PR DESCRIPTION
Cuda 10.1 is not supported by newer pytorch versions, so conda will install the cpu version instead. Based on https://download.pytorch.org/whl/torch_stable.html, the newest versions of pytorch and  torchvision that are compatible with cuda 10.1 are torchvision 0.9.1 and torch 1.8.1.